### PR TITLE
ci(release): bump workflow actions and node runtime

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,18 +11,18 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
           version: 9
           run_install: false
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org/"
 
       - name: install dependencies


### PR DESCRIPTION
- bump `actions/checkout` from v4 to v6
- bump `pnpm/action-setup` from v2 to v6
- bump `actions/setup-node` from v4 to v6
- bump `node-version` from 20 to 22